### PR TITLE
Tweaks for Reducto dev/prod

### DIFF
--- a/README-sema4.md
+++ b/README-sema4.md
@@ -11,6 +11,7 @@ reducto_helm_repo_username = "ram@sema4.ai"
 reducto_helm_repo_password = "..."
 reducto_host = "reducto.sema4ai.dev"
 openai_api_key = "..."
+reducto_nlb_cert_arn = "..."
 ```
 
 ## Choosing environments
@@ -20,4 +21,4 @@ We use the partial configuration of backend to support multiple environments.
 Before running a `terraform plan|apply`, run the corresponding `make init-dev` or `make init-prod` to
 reconfigure your local Terraform project for the dev/prod environment.
 
-Then, the corresponding make targets `make plan-dev`/`make plan-prod` or `make apply-dev`/`make apply-prod`
+Then, the corresponding make targets `make plan-dev`/`make plan-prod` or `make apply-dev`/`make apply-prod`.

--- a/ingress-nginx-controller.tf
+++ b/ingress-nginx-controller.tf
@@ -7,7 +7,9 @@ resource "helm_release" "ingress_nginx" {
   create_namespace = true
 
   values = [
-    "${file("values/ingress-nginx-controller.yaml")}",
+    templatefile("${path.module}/values/ingress-nginx-controller.yaml", {
+      reducto_nlb_cert_arn = var.reducto_nlb_cert_arn
+    })
   ]
 
   depends_on = [

--- a/values/ingress-nginx-controller.yaml
+++ b/values/ingress-nginx-controller.yaml
@@ -44,6 +44,6 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type                     : "ip"
       service.beta.kubernetes.io/aws-load-balancer-type                                : "nlb"
       service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules : "true"
-      service.beta.kubernetes.io/aws-load-balancer-ssl-cert                            : "arn:aws:acm:us-east-1:004078808828:certificate/b3c1abaf-a599-44df-ba0e-74bb173d3404"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert                            : "${reducto_nlb_cert_arn}"
     targetPorts:
       https: http # re-map https port on frontend to be http on backend

--- a/variables.tf
+++ b/variables.tf
@@ -78,4 +78,9 @@ variable "openai_api_key" {
   sensitive = true
 }
 
+variable "reducto_nlb_cert_arn" {
+  description = "ARN of the SSL certificate for the NLB"
+  type        = string
+}
+
 


### PR DESCRIPTION
* Templatize the ARN of the certificate for the Reducto NLB
* Set ARN for dev.

This enabled Reducto deploys in dev.