### PR TITLE
Upgrade to kubernetes 1.32. Bump to compatible plugins

### DIFF
--- a/docs/eks-upgrade-runbook.md
+++ b/docs/eks-upgrade-runbook.md
@@ -1,0 +1,117 @@
+# EKS Upgrade Runbook
+
+One Kubernetes minor per hop (1.31 → 1.32 → 1.33). Control-plane upgrades
+cannot be rolled back. Addons must be bumped in the same hop (kube-proxy may
+not lag more than one minor).
+
+## 1. Apply
+
+```bash
+make apply-<env>
+```
+
+Expected, in order (~20–30 min total):
+
+| What | Expect |
+|---|---|
+| Control plane | `Still modifying...` ~10–15 min, then 1.3x+1 |
+| Addons | Updated to the pins; DaemonSets roll |
+| Managed node groups (`system`/`startup`) | Roll automatically to new AMI |
+| Karpenter EC2NodeClass | Alias updated; existing nodes marked drifted (they do NOT roll yet) |
+| helm_release.reducto | Updated (has `wait = false`; verify pods yourself) |
+
+Verify:
+
+```bash
+kubectl get nodes -o wide                                   # MNG nodes on target version
+for a in coredns kube-proxy vpc-cni aws-ebs-csi-driver eks-pod-identity-agent; do
+  echo "$a: $(aws eks describe-addon --cluster-name reducto-ai --addon-name $a --query addon.status --output text)"
+done                                                        # all ACTIVE
+kubectl get pods -n kube-system -l k8s-app=aws-node | grep -v "2/2"   # empty
+kubectl get pods -n reducto                                 # Running/Completed
+```
+
+## 4. Roll the Karpenter nodes
+
+All reducto pods (workers AND http) carry `karpenter.sh/do-not-disrupt`, which
+blocks Karpenter's automatic drift replacement indefinitely. Old nodes stay
+until every annotated pod is off them; Karpenter then reaps the node itself —
+never `kubectl delete node`.
+
+**Cordon all old nodes first** so rescheduled pods can't land back on old
+capacity (safe, instant, running pods untouched):
+
+```bash
+kubectl get nodes -o name -l karpenter.sh/nodepool=default | xargs kubectl cordon
+# new nodes Karpenter creates come up uncordoned
+```
+
+Then empty one node at a time. See what pins it:
+
+```bash
+kubectl get pods -A --field-selector spec.nodeName=<node> --no-headers | grep -v Completed
+```
+
+- **Stateless pods (http, UI)**: `kubectl delete pod -n reducto <pod>` any
+  time the sibling replica is Ready. Deployment recreates it on a new node.
+- **Workers**: wait for the job to finish (node is reaped the moment it's
+  unpinned), or delete the pod when killing that job is acceptable.
+- **Whole node now, jobs included** (prod: maintenance window):
+
+  ```bash
+  kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --disable-eviction
+  ```
+
+Let each replacement go Ready (~3–5 min, `aws-node` 2/2) before taking the next
+node. Done when:
+
+```bash
+kubectl get nodes -o wide          # only new-AMI nodes remain, none cordoned
+kubectl get nodeclaims -o wide     # no old IMAGEID rows
+```
+
+Gotcha: draining a node does not by itself make Karpenter launch a replacement
+— it only provisions when pods are Pending. If a drained node's pods all fit on
+existing capacity, the node just disappears.
+
+## Failure modes
+
+**Plan wants to replace/destroy Karpenter IAM attachments.**
+Cause: module-level `depends_on` deferring data sources → `policy_arn`
+"known after apply" → forced replacement. This should be fixed permanently
+(`karpenter.tf` passes `cluster_name = module.eks.cluster_name`, no module
+`depends_on`). Do not apply; find what reintroduced the deferral.
+
+**Apply fails / is interrupted; addons stuck `UPDATING`; later applies 409.**
+Every apply will 409 until the addon converges, and the addon usually can't
+converge because pods can't pull. Fix the pull problem out-of-band (CLI/kubectl,
+not terraform), wait for `ACTIVE`, then re-run the full apply to reconcile
+state. `-target` does not help — everything drags in `module.eks`.
+
+**Pods `ImagePullBackOff`, `no basic auth credentials`.**
+The node role lost ECR access (this is what the destroyed IAM attachments look
+like from the cluster). Re-attach out-of-band, then bounce the stuck pods:
+
+```bash
+for P in AmazonEKSWorkerNodePolicy AmazonEC2ContainerRegistryReadOnly AmazonEKS_CNI_Policy; do
+  aws iam attach-role-policy --role-name <Karpenter-node-role> --policy-arn arn:aws:iam::aws:policy/$P
+done
+kubectl delete pod -n kube-system -l k8s-app=aws-node --field-selector status.phase!=Running
+```
+
+**New Karpenter nodes launch but never join, instance shows "user initiated
+shutdown".**
+Bottlerocket ≥ ~1.30 calls `ec2:DescribeInstances` at boot; without it the node
+powers off. Confirm `aws_iam_role_policy.karpenter_node_describe_instances`
+(karpenter.tf) is applied. Diagnose via
+`aws ec2 get-console-output --instance-id <id> --latest`.
+
+**Karpenter drains a node but no replacement appears.**
+Nothing is Pending, so Karpenter has no reason to launch. Cordon the old
+Karpenter nodes, then delete a worker pod to force a launch.
+
+**helm fails: `spec.trafficDistribution: Unsupported value: "PreferSameZone"`.**
+The Reducto chart emits `PreferSameZone` on k8s ≥1.31 but it's only valid on
+1.34+. Keep `setTrafficDistribution: "PreferClose"` in `values/reducto.yaml`
+until the cluster is on 1.34.
+

--- a/eks.tf
+++ b/eks.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "20.26.0"
 
   cluster_name    = var.cluster_name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   cluster_endpoint_public_access       = var.cluster_endpoint_public_access
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
@@ -21,7 +21,7 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      addon_version     = "v1.11.3-eksbuild.1"
+      addon_version     = "v1.11.4-eksbuild.39"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         autoScaling = {
@@ -59,7 +59,7 @@ module "eks" {
     }
 
     eks-pod-identity-agent = {
-      addon_version     = "v1.3.2-eksbuild.2"
+      addon_version     = "v1.3.10-eksbuild.3"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -75,7 +75,7 @@ module "eks" {
     }
 
     kube-proxy = {
-      addon_version     = "v1.30.3-eksbuild.9"
+      addon_version     = "v1.32.13-eksbuild.14"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -91,7 +91,7 @@ module "eks" {
     }
 
     vpc-cni = {
-      addon_version     = "v1.18.5-eksbuild.1"
+      addon_version     = "v1.21.2-eksbuild.2"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -108,7 +108,7 @@ module "eks" {
 
     aws-ebs-csi-driver = {
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
-      addon_version            = "v1.36.0-eksbuild.1"
+      addon_version            = "v1.63.0-eksbuild.1"
       resolve_conflicts        = "OVERWRITE"
 
       configuration_values = jsonencode({

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -2,7 +2,13 @@ module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   version = "20.33.1"
 
-  cluster_name = var.cluster_name
+  # Dependency on module.eks is plumbed through the output on purpose. A
+  # module-level depends_on defers every data source in this module to apply
+  # time whenever module.eks has pending changes, which turns the node role's
+  # policy attachments into forced replacements (policy_arn becomes unknown).
+  # The detach then runs early in the apply and the re-attach is skipped if
+  # anything in module.eks fails, leaving nodes unable to pull from ECR.
+  cluster_name = module.eks.cluster_name
 
   enable_v1_permissions           = true
   enable_pod_identity             = true
@@ -12,8 +18,22 @@ module "karpenter" {
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
+}
 
-  depends_on = [module.eks]
+# Bottlerocket's pluto calls ec2:DescribeInstances at boot to resolve the node's
+# private DNS name; without it the node fails to bootstrap and powers off.
+resource "aws_iam_role_policy" "karpenter_node_describe_instances" {
+  name = "bottlerocket-describe-instances"
+  role = module.karpenter.node_iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ec2:DescribeInstances"]
+      Resource = "*"
+    }]
+  })
 }
 
 resource "helm_release" "karpenter" {
@@ -55,7 +75,7 @@ resource "kubectl_manifest" "karpenter_node_class" {
       name: default
     spec:
       amiSelectorTerms:
-      - alias: bottlerocket@v1.29.0
+      - alias: bottlerocket@v1.63.0
       userData: |
         [settings.kubernetes]
         image-gc-low-threshold-percent = "50"

--- a/reducto-db.tf
+++ b/reducto-db.tf
@@ -16,7 +16,7 @@ module "rds" {
 
   identifier           = var.cluster_name
   engine               = "postgres"
-  engine_version       = "16.8"
+  engine_version       = "16.13"
   family               = "postgres16" # DB parameter group
   major_engine_version = "16"         # DB option group
   instance_class       = var.db_instance_class

--- a/values/reducto.yaml
+++ b/values/reducto.yaml
@@ -1,3 +1,7 @@
+# Chart auto-selects PreferSameZone on k8s >=1.31, but that value is only valid
+# on 1.34+. Pin the equivalent stable value; drop once the cluster is on 1.34.
+setTrafficDistribution: "PreferClose"
+
 http:
   podDisruptionBudget:
     enabled: true


### PR DESCRIPTION
Set Reducto 1.11.80

This has been applied in dev already. I will consider doing this in prod later this week (we'll see how the week goes).

Should be pretty normal. Two odd things:
* Change the traffic distribution as the helm chart from reducto refers to an enum value that doesnt' show up until 1.33 or 1.34
* change the Karpenter definition as the resolution dropped a bunch of IAM policies from a role silently and didn't re-add them. 